### PR TITLE
Issue #5 - Replace Buildly UI to Buildly-React-Template

### DIFF
--- a/robot-tests/buildly-react-template/login.robot
+++ b/robot-tests/buildly-react-template/login.robot
@@ -9,6 +9,6 @@ Documentation   Application Login
 
 *** Test Cases ***
 Register new user
-    GIVEN browser is opened to Buildly-UI url
+    GIVEN browser is opened to Buildly-React-Template url
     WHEN a new user is registered
-    THEN the user can login
+    THEN the user can login 


### PR DESCRIPTION

## Purpose
Needed to replace the React UI word / folder name to Buildly React Template

## Approach
Changed buildly-ui word / folder name to buildly-react-template

### Further Info
Ticket number: #5 
 
@jefmoura 
