### PR TITLE
Issue #5 - Replace the Buildly UI word to Buildly-React-Template 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -148,9 +148,9 @@ services:
         -----END PUBLIC KEY-----
       SECRET_KEY: "oxcdb=mtcc7q1cym@oox(lyrz1ncz-(w+(#&u7l-&)7a8wvxyz"
 
-  buildly-ui:
-    container_name: buildly-ui
-    image: buildly/buildly-ui
+  buildly-react-template:
+    container_name: buildly-react-template
+    image: buildly/buildly-react-template
     ports:
       - "9001:9000"
     depends_on:
@@ -178,3 +178,4 @@ services:
 
 volumes:
   static-content:
+


### PR DESCRIPTION
## Purpose
Need to replace the Buildly UI Docker image to Buildly React Template

## Approach
Changed the buildly-ui word to buildly-react-template

### Further Info
Ticket number: #5
 
@jefmoura 
