### PR TITLE
Issue #5 - Replace Buildly UI to Buildly-React-Template

### DIFF
--- a/robot-tests/keywords.robot
+++ b/robot-tests/keywords.robot
@@ -2,10 +2,12 @@
 Library    SeleniumLibrary
 Library    ./get_selenium_browser_log.py
 Library    Process
+Library    BuiltIn
 
 *** Variables ***
 @{chrome_arguments}    --disable-infobars    --headless    --disable-gpu   --no-sandbox   --window-size=1920,1080
 ${HEADLESS_BROWSER_ENABLED}     True
+${env}      
 
 *** Keywords ***
 Init
@@ -58,7 +60,8 @@ I am authenticated api user
     Should Be Equal As Strings  ${resp.status_code}  200
 
 Set environment
-    Run Keyword If    '${env}'!=''    Set environment to   ${env}
+    Run Keyword If    '${env}'!=''  Set environment to  ${env}
+    # Run Keyword If    '${env}'=='PASS'    Set environment to    ${env}  
 
 Set environment to
     [Arguments]    ${env}
@@ -68,7 +71,7 @@ Set environment to
     Set Global Variable    ${REGULAR_USER_PASSWORD}          ${REGULAR_USER_PASSWORD_${env}}
     Set Global Variable    ${API_USER_USERNAME}              ${API_USER_USERNAME_${env}}
     Set Global Variable    ${API_USER_PASSWORD}              ${API_USER_PASSWORD_${env}}
-    Set Global Variable    ${BUILDLY_UI_BASE_URL}            ${BUILDLY_UI_BASE_URL_${env}}
+    Set Global Variable    ${BUILDLY_REACT_TEMPLATE_BASE_URL}            ${BUILDLY_REACT_TEMPLATE_BASE_URL_${env}}
     Set Global Variable    ${BUILDLY_BASE_URL}               ${BUILDLY_BASE_URL_${env}}
     Set Global Variable    ${PRODUCT_API_BASE_URL}           ${PRODUCT_API_BASE_URL_${env}}
     Set Global Variable    ${LOCATION_API_BASE_URL}          ${LOCATION_API_BASE_URL_${env}}

--- a/robot-tests/variables.robot
+++ b/robot-tests/variables.robot
@@ -6,7 +6,7 @@ ${API_USER_USERNAME}              admin
 ${API_USER_PASSWORD}              admin
 ${REGULAR_USER_USERNAME}          admin
 ${REGULAR_USER_PASSWORD}          admin
-${BUILDLY_UI_BASE_URL}            http://localhost:9001
+${BUILDLY_REACT_TEMPLATE_BASE_URL}                  http://localhost:9001
 ${BUILDLY_BASE_URL}               http://localhost:8080
 ${PRODUCT_API_BASE_URL}           ${BUILDLY_BASE_URL}/products
 ${LOCATION_API_BASE_URL}          ${BUILDLY_BASE_URL}/locations
@@ -18,7 +18,7 @@ ${API_USER_USERNAME_docker}              admin
 ${API_USER_PASSWORD_docker}              admin
 ${REGULAR_USER_USERNAME_docker}          admin
 ${REGULAR_USER_PASSWORD_docker}          admin
-${BUILDLY_UI_BASE_URL_docker}            http://buildly-ui:9000
+${BUILDLY_REACT_TEMPLATE_BASE_URL_docker}            http://buildly-react-template:9000
 ${BUILDLY_BASE_URL_docker}               http://buildly:8080
 ${PRODUCT_API_BASE_URL_docker}           ${BUILDLY_BASE_URL_docker}/products
 ${LOCATION_API_BASE_URL_docker}          ${BUILDLY_BASE_URL_docker}/locations


### PR DESCRIPTION
## Purpose
Needed to replace the React UI word to Buildly React Template

## Approach
Changed buildly-ui word to buildly-react-template

### Further Info
Ticket number: #5 
 
@jefmoura 
