### PR TITLE
Issue #5 - Replace Buildly UI to Buildly-React-Template 

### DIFF
--- a/robot-tests/buildly-ui/login.robot
+++ b/robot-tests/buildly-ui/login.robot
@@ -9,6 +9,8 @@ Documentation   Application Login
 
 *** Test Cases ***
 Register new user
-    GIVEN browser is opened to Buildly-UI url
+    GIVEN browser is opened to Buildly-React-Template url
     WHEN a new user is registered
-    THEN the user can login
+    THEN the user can login 
+
+


### PR DESCRIPTION
## Purpose
Needed to replace the Buildly UI word to Buildly React Template

## Approach
Changed buildly-ui to buildly-react-template

### Further Info
Ticket number: #5 
 
@jefmoura 
